### PR TITLE
add handlebars export

### DIFF
--- a/handlebars.js
+++ b/handlebars.js
@@ -2744,3 +2744,5 @@ var __module0__ = (function(__dependency1__, __dependency2__, __dependency3__, _
 
   return __module0__;
 })();
+
+module.exports = Handlebars;


### PR DESCRIPTION
otherwise `require('handlebars-js')` returns an empty object, when using component
