### PR TITLE
package.json for jspm compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@ Package Managers
 * [Bower](http://twitter.github.com/bower/): `handlebars`
 * [Component](http://github.com/component/component): `components/handlebars.js`
 * [Composer](http://packagist.org/packages/components/handlebars.js): `components/handlebars.js`
+* [jspm](http://jspm.io): `github:components/handlebars.js`

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "jspm": {
+    "main": "handlebars",
+    "shim": { "handlebars": { "exports": "Handlebars" } },
+    "files": ["handlebars.js"],
+    "buildConfig": { "minify": true }
+  }
+}


### PR DESCRIPTION
Ultimate goal for this change is that ember can be installed via `jspm install github:components/ember`

jspm is a quite interesting package manager since it works in conjunction with SystemJS and traceur. It enables us to use ES6 modules now.
