### PR TITLE
do not require deprecated repo, just suggest it

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
             "homepage": "http://chriswanstrath.com"
         }
     ],
-    "require": {
-        "robloach/component-installer": "*"
+    "suggest": {
+        "robloach/component-installer": "Allows installation of Components via Composer"
     },
     "extra": {
         "component": {


### PR DESCRIPTION
Requiring robloach/component-installer forces others to use it, but this library is deprecated now and is not convenient to use.