### PR TITLE
Add version and license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,6 @@
 {
+  "version": "4.0.11",
+  "license": "MIT",
   "jspm": {
     "main": "handlebars",
     "shim": { "handlebars": { "exports": "Handlebars" } },


### PR DESCRIPTION
Missing package version causes `yarn` to generate invalid `yarn.lock` if repository is added as a dependency. See issue #23 for details.

How to verify the fix (in comparison to the failing sequence in issue #23):

Use following minimal `package.json`

```
{
  "name": "yarn-install-failure",
  "version": "1.0.0",
  "dependencies": {
    "@bower_components/handlebars": "hsalokor/handlebars.js#fix/add-version"
  },
  "license": "UNLICENCED"
}
```

Run yarn install twice:

```
$ yarn install
yarn install v1.3.2
info No lockfile found.
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 📃  Building fresh packages...
success Saved lockfile.
✨  Done in 1.45s.

$ yarn install
yarn install v1.3.2
[1/4] 🔍  Resolving packages...
success Already up-to-date.
✨  Done in 0.14s.
```

Generated `yarn.lock` now has correct version.

```
# THIS IS AN AUTOGENERATED FILE. DO NOT EDIT THIS FILE DIRECTLY.
# yarn lockfile v1


"@bower_components/handlebars@hsalokor/handlebars.js#fix/add-version":
  version "4.0.11"
  resolved "https://codeload.github.com/hsalokor/handlebars.js/tar.gz/7a2f72c28b1ee2382304a42d2676ccd853407bd6"
```

Drawback of this fix is that version bumps require editing of the `package.json`.